### PR TITLE
Change name separator

### DIFF
--- a/Bot.py
+++ b/Bot.py
@@ -10,7 +10,7 @@ from signal import signal, SIGINT
 
 import RadioIDs
 
-VERSION = "2.1.8"
+VERSION = "2.1.9"
 
 log = logging.getLogger()
 
@@ -264,7 +264,7 @@ class Bot:
 
         if peopleStrings:
             tweet = "{} ({}) {}".format(
-                callString, ", ".join(peopleStrings), self.HASHTAGS,
+                callString, "; ".join(peopleStrings), self.HASHTAGS,
             )
         else:
             tweet = "{} {}".format(callString, self.HASHTAGS,)


### PR DESCRIPTION
Use a different separator for the list of names/badge numbers so there isn't ambiguity between different person vs same person but badge and name.
Is it useful? Maybe? Does it annoy me slightly that the same punctuation mark is used for two different things? Yea