### PR TITLE
Pin tweepy to <4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-tweepy>=3.10.0
+tweepy>=3.10.0,<4.0.0
 python-socketio==4.6.1
 pytz>=2021.1
 cachetools>=4.2.2


### PR DESCRIPTION
In attempting to deploy the latest version, I ran into the following issue:

```python
Traceback (most recent call last):
  File "/app/Bot.py", line 5, in <module>
    from tweepy.error import TweepError
ModuleNotFoundError: No module named 'tweepy.error'
```

It looks like this is due to breaking changes with tweepy>=4.0.0[^1]. I used this change in production and was able to build/deploy the bot successfully.

[^1]: https://docs.tweepy.org/en/latest/changelog.html#version-4-0-0
