### PR TITLE
[Feature] Tweepy 4.0.0 support

### DIFF
--- a/Bot.py
+++ b/Bot.py
@@ -3,7 +3,6 @@ from datetime import datetime, timedelta
 from typing import List
 import tweepy, json, pytz, socketio
 from tweepy.errors import Unauthorized as tweepy_unauthorized
-from tweepy.errors import TweepyException
 from signal import signal, SIGINT
 
 import RadioIDs

--- a/Bot.py
+++ b/Bot.py
@@ -7,7 +7,7 @@ from signal import signal, SIGINT
 
 import RadioIDs
 
-VERSION = "2.1.14"
+VERSION = "3.0.0"
 
 log = logging.getLogger()
 

--- a/Bot.py
+++ b/Bot.py
@@ -59,7 +59,7 @@ class Bot:
             # Test the authentication. This will gracefully fail if the keys aren't present.
             try:
                 self._api.verify_credentials()
-            except tweepy_unauthorized as e:
+            except TweepyUnauthorized as e:
                 log.error(f"No keys or bad keys: {e}")
                 exit(1)
 

--- a/Bot.py
+++ b/Bot.py
@@ -2,7 +2,7 @@ import logging, os
 from datetime import datetime, timedelta
 from typing import List
 import tweepy, json, pytz, socketio
-from tweepy.errors import TweepyException
+from tweepy.errors import Unauthorized as tweepy_unauthorized
 from signal import signal, SIGINT
 
 import RadioIDs
@@ -59,11 +59,8 @@ class Bot:
             # Test the authentication. This will gracefully fail if the keys aren't present.
             try:
                 self._api.rate_limit_status()
-            except TweepyException as e:
-                if e.api_code == 215:
-                    log.error("No keys or bad keys")
-                else:
-                    log.error("Other API error: {}".format(e))
+            except tweepy_unauthorized as e:
+                log.error("No keys or bad keys")
                 exit(1)
 
         # Register interput handler

--- a/Bot.py
+++ b/Bot.py
@@ -2,7 +2,7 @@ import logging, os
 from datetime import datetime, timedelta
 from typing import List
 import tweepy, json, pytz, socketio
-from tweepy.errors import Unauthorized as tweepy_unauthorized
+from tweepy.errors import Unauthorized as TweepyUnauthorized
 from signal import signal, SIGINT
 
 import RadioIDs

--- a/Bot.py
+++ b/Bot.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 from typing import List
 import tweepy, json, pytz, socketio
 from tweepy.errors import Unauthorized as tweepy_unauthorized
+from tweepy.errors import TweepyException
 from signal import signal, SIGINT
 
 import RadioIDs
@@ -162,7 +163,7 @@ class Bot:
                             msg, self._cachedTweet
                         ).id
             self._cachedTime = datetime.now()
-        except tweepy.TweepError as e:
+        except tweepy.TweepyException as e:
             log.exception(e)
 
     def _timeString(self, call: dict) -> str:

--- a/Bot.py
+++ b/Bot.py
@@ -60,7 +60,7 @@ class Bot:
             try:
                 self._api.verify_credentials()
             except tweepy_unauthorized as e:
-                log.error("No keys or bad keys")
+                log.error(f"No keys or bad keys: {e}")
                 exit(1)
 
         # Register interput handler

--- a/Bot.py
+++ b/Bot.py
@@ -2,7 +2,7 @@ import logging, os
 from datetime import datetime, timedelta
 from typing import List
 import tweepy, json, pytz, socketio
-from tweepy.error import TweepError
+from tweepy.errors import TweepyException
 from signal import signal, SIGINT
 
 import RadioIDs
@@ -59,7 +59,7 @@ class Bot:
             # Test the authentication. This will gracefully fail if the keys aren't present.
             try:
                 self._api.rate_limit_status()
-            except TweepError as e:
+            except TweepyException as e:
                 if e.api_code == 215:
                     log.error("No keys or bad keys")
                 else:

--- a/Bot.py
+++ b/Bot.py
@@ -59,7 +59,7 @@ class Bot:
             self._api = tweepy.API(auth)
             # Test the authentication. This will gracefully fail if the keys aren't present.
             try:
-                self._api.rate_limit_status()
+                self._api.verify_credentials()
             except tweepy_unauthorized as e:
                 log.error("No keys or bad keys")
                 exit(1)
@@ -151,7 +151,7 @@ class Bot:
                 for msg in msgs:
                     # Every time it posts the new ID gets stored so this works
                     self._cachedTweet = self._api.update_status(
-                        msg, self._cachedTweet
+                        msg, in_reply_to_status_id=self._cachedTweet
                     ).id
             else:
                 for index, msg in enumerate(msgs):
@@ -160,7 +160,7 @@ class Bot:
                         self._cachedTweet = self._api.update_status(msg).id
                     else:
                         self._cachedTweet = self._api.update_status(
-                            msg, self._cachedTweet
+                            msg, in_reply_to_status_id=self._cachedTweet
                         ).id
             self._cachedTime = datetime.now()
         except tweepy.TweepyException as e:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-tweepy>=3.10.0,<4.0.0
+tweepy>=4.0.0
 python-socketio==4.6.1
 pytz>=2021.1
 cachetools>=4.2.2


### PR DESCRIPTION
Change code to be able to use Tweepy>=4.0.0
Any previous version of the bot will not work with Tweepy>=4.0.0 and no Tweepy version <=4.0.0 will work with the bot going forward (run your `pip --upgrades`).