### PR TITLE
Use only last name in Tweets

### DIFF
--- a/Bot.py
+++ b/Bot.py
@@ -256,7 +256,7 @@ class Bot:
                 peopleStrings.append(
                     self.twitterConfig["names"].format(
                         person["badge"],
-                        person["full_name"],
+                        person["last_name"],
                     )
                 )
 


### PR DESCRIPTION
Close #28; I see a potential problem with this if two or more officers share a last name? But that would be addressed by addressing #29.